### PR TITLE
Make S3 credentials be specified by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,6 @@ viewports:
   small:
     width: 320
     height: 444
-s3_access_key_id: <your acccess key id>
-s3_secret_access_key: <your secret acccess key>
-s3_bucket_name: <a globally unique bucket name>
 ```
 
 ## Command line tools
@@ -177,8 +174,25 @@ and you can do use your developer tools to debug.
 ### `happo upload_diffs`
 
 Uploads all current diff images to an Amazon S3 account and reports back URLs
-to access those diff images. Requires the `s3_access_key_id`,
-`s3_secret_access_key`, and `s3_bucket_name` configuration options.
+to access those diff images. Requires that `S3_ACCESS_KEY_ID`,
+`S3_SECRET_ACCESS_KEY`, and `S3_BUCKET_NAME` are specified as environment
+variables. `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` will be the
+credentials Happo uses to access the bucket named `S3_BUCKET_NAME`.
+`S3_BUCKET_PATH` can also be set as an environment variable to specify a
+directory path for where you want diff images uploaded within the S3 bucket.
+You can set these in the session by using `export`:
+```sh
+export S3_ACCESS_KEY_ID=<YOUR_ACCESS_KEY_VALUE>
+export S3_SECRET_ACCESS_KEY=<YOUR_SECRET_ACCESS_KEY_VALUE>
+export S3_BUCKET_NAME=<YOUR_BUCKET_NAME>
+export S3_BUCKET_PATH=<YOUR_BUCKET_PATH>
+
+happo upload_diffs
+```
+or by adding them in the beginning of the command:
+```sh
+S3_ACCESS_KEY_ID=<...> S3_SECRET_ACCESS_KEY=<...> ... happo upload_diffs
+```
 
 ### `happo clean`
 

--- a/lib/happo/uploader.rb
+++ b/lib/happo/uploader.rb
@@ -4,9 +4,10 @@ require 'securerandom'
 module Happo
   class Uploader
     def initialize
-      @s3_access_key_id = Happo::Utils.config['s3_access_key_id']
-      @s3_secret_access_key = Happo::Utils.config['s3_secret_access_key']
-      @s3_bucket_name = Happo::Utils.config['s3_bucket_name']
+      @s3_access_key_id = ENV['S3_ACCESS_KEY_ID']
+      @s3_secret_access_key = ENV['S3_SECRET_ACCESS_KEY']
+      @s3_bucket_name = ENV['S3_BUCKET_NAME']
+      @s3_bucket_path = ENV['S3_BUCKET_PATH']
     end
 
     def upload_diffs
@@ -17,7 +18,11 @@ module Happo
                    result_summary[:new_examples].empty?
 
       bucket = find_or_build_bucket
-      dir = SecureRandom.uuid
+      if @s3_bucket_path.nil? || @s3_bucket_path.empty?
+        dir = SecureRandom.uuid
+      else
+        dir = File.join(@s3_bucket_path, SecureRandom.uuid)
+      end
 
       diff_images = result_summary[:diff_examples].map do |diff|
         image = bucket.objects.build(


### PR DESCRIPTION
The S3 credentials used for uploading diff images are now required to be
specified by environment variables, instead of in the `.happo.yaml`
file. Users must set `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, and
`S3_BUCKET_NAME` as environment variables to use `happo upload_diffs`.
Users can also set `S3_BUCKET_PATH` as an environment variable if they
wish to specify a directory path for where they want diff images
uploaded within the S3 bucket. This also addresses https://github.com/Galooshi/happo/issues/91.