### PR TITLE
Get single S3 bucket instead of all buckets

### DIFF
--- a/lib/happo/uploader.rb
+++ b/lib/happo/uploader.rb
@@ -62,9 +62,9 @@ module Happo
     def find_or_build_bucket
       service = S3::Service.new(access_key_id: @s3_access_key_id,
                                 secret_access_key: @s3_secret_access_key)
-      bucket = service.buckets.find(@s3_bucket_name)
+      bucket = service.bucket(@s3_bucket_name)
 
-      if bucket.nil?
+      if !bucket.exists?
         bucket = service.buckets.build(@s3_bucket_name)
         bucket.save(location: :us)
       end


### PR DESCRIPTION
Asking for all buckets may lead to access denied errors if the IAM role or user
associated with the provided access key pair does not have permissions for all
buckets. Furthermore, we only need to retrieve the bucket specified by the
environment variable `S3_BUCKET_NAME` to put diff images into, and we should
definitely have access to `S3_BUCKET_NAME` with the provided S3 credentials. Thus, we should use `service.bucket(@s3_bucket_name)` instead of `service.buckets.find(@s3_bucket_name)`.

For some reason, the `service.bucket("bucket_name")` method was not specified
in the README for the `s3` library, and the only example in the documentation
for finding a single bucket was `service.buckets.find("bucket_name")`. I have
submitted a pull request to update the documentation there as well: https://github.com/qoobaa/s3/pull/116. Also, since
`service.bucket(...)` doesn't check whether the bucket with the given name
exists, we should use the provided `exists?` method from the library to check
whether the bucket actually exists.