### PR TITLE
Remove unnecessary line for building S3 buckets

### DIFF
--- a/lib/happo/uploader.rb
+++ b/lib/happo/uploader.rb
@@ -65,7 +65,6 @@ module Happo
       bucket = service.bucket(@s3_bucket_name)
 
       if !bucket.exists?
-        bucket = service.buckets.build(@s3_bucket_name)
         bucket.save(location: :us)
       end
 


### PR DESCRIPTION
In https://github.com/Galooshi/happo/pull/93, we changed from using
`service.buckets.find` in `uploader.rb` to `service.bucket`. However, I
forgot to change the line that used `service.buckets.build`, which
instantiates a new bucket just as `service.bucket` does.
`service.buckets.build` does use a `proxy_owner` argument, which is
actually just `service` since that argument is passed into
`BucketExtensions` as `self` in `service.buckets`
(https://github.com/qoobaa/s3/blob/ec570632d25a3571cd4585de08e48e72b838f048/lib/s3/service.rb#L48).
`service.bucket` also creates a bucket with `self` for the same argument
(https://github.com/qoobaa/s3/blob/ec570632d25a3571cd4585de08e48e72b838f048/lib/s3/service.rb#L55).
Thus, the bucket `service.buckets.build` creates should be identical
to a bucket created by `service.bucket`.