### PR TITLE
Show 404 error for file not found

### DIFF
--- a/lib/happo/server.rb
+++ b/lib/happo/server.rb
@@ -43,14 +43,18 @@ module Happo
       file = params[:splat].first
       if File.exist?(file)
         send_file file
+        return
       else
         config['public_directories'].each do |pub_dir|
           filepath = File.join(Dir.pwd, pub_dir, file)
           if File.exist?(filepath)
             send_file filepath
+            return
           end
         end
       end
+      status 404 # not found
+      body '404 error: not found'
     end
 
     run!


### PR DESCRIPTION
This commit deals with this issue
https://github.com/Galooshi/happo/issues/95. Now, if you run `happo
debug` and try to go to a file that cannot be found, a 404 error is
raised. Previously, you would have gotten a 202 error if a file could
not be found. I missed this bug in
https://github.com/Galooshi/happo/pull/86.