### PR TITLE
Use relative paths instead of absolute paths for images

### DIFF
--- a/lib/happo/uploader.rb
+++ b/lib/happo/uploader.rb
@@ -25,26 +25,26 @@ module Happo
             end
 
       diff_images = result_summary[:diff_examples].map do |diff|
-        image = bucket.objects.build(
-          "#{dir}/#{diff[:description]}_#{diff[:viewport]}.png")
+        img_url = "#{dir}/#{diff[:description]}_#{diff[:viewport]}.png"
+        image = bucket.objects.build(img_url)
         image.content = open(Happo::Utils.path_to(diff[:description],
                                                      diff[:viewport],
                                                      'diff.png'))
         image.content_type = 'image/png'
         image.save
-        diff[:url] = image.url
+        diff[:url] = img_url
         diff
       end
 
       new_images = result_summary[:new_examples].map do |example|
-        image = bucket.objects.build(
-          "#{dir}/#{example[:description]}_#{example[:viewport]}.png")
+        img_url = "#{dir}/#{example[:description]}_#{example[:viewport]}.png"
+        image = bucket.objects.build(img_url)
         image.content = open(Happo::Utils.path_to(example[:description],
                                                      example[:viewport],
                                                      'previous.png'))
         image.content_type = 'image/png'
         image.save
-        example[:url] = image.url
+        example[:url] = img_url
         example
       end
 


### PR DESCRIPTION
With this change, the image elements in the generated `index.html` for
`happo upload_diffs` will use relative paths instead of absolute paths
for their source urls.

In my case, I'm using a proxy to allow developers without access to the
S3 bucket containing the image and HTML files Happo creates to also see
the visual diffing images. I would like to use the generated
`index.html` to present the visual diffing images, but the browser would
not have the access to get to the absolute paths leading to the S3 bucket for
the images. Using relative paths allows the images to be retrieved using
the proxy as well.