### PR TITLE
Fix uploader to use correct relative paths

### DIFF
--- a/lib/happo/uploader.rb
+++ b/lib/happo/uploader.rb
@@ -25,26 +25,26 @@ module Happo
             end
 
       diff_images = result_summary[:diff_examples].map do |diff|
-        img_url = "#{dir}/#{diff[:description]}_#{diff[:viewport]}.png"
-        image = bucket.objects.build(img_url)
+        img_name = "#{diff[:description]}_#{diff[:viewport]}.png"
+        image = bucket.objects.build("#{dir}/#{img_name}")
         image.content = open(Happo::Utils.path_to(diff[:description],
                                                      diff[:viewport],
                                                      'diff.png'))
         image.content_type = 'image/png'
         image.save
-        diff[:url] = img_url
+        diff[:url] = img_name
         diff
       end
 
       new_images = result_summary[:new_examples].map do |example|
-        img_url = "#{dir}/#{example[:description]}_#{example[:viewport]}.png"
-        image = bucket.objects.build(img_url)
+        img_name = "#{example[:description]}_#{example[:viewport]}.png"
+        image = bucket.objects.build("#{dir}/#{img_name}")
         image.content = open(Happo::Utils.path_to(example[:description],
                                                      example[:viewport],
                                                      'previous.png'))
         image.content_type = 'image/png'
         image.save
-        example[:url] = img_url
+        example[:url] = img_name
         example
       end
 


### PR DESCRIPTION
In https://github.com/Galooshi/happo/pull/98, I wanted the `index.html`
file generated by `happo upload_diffs` to use relative paths for the
visual diffing screenshots, rather than absolute paths. However, the
images and `index.html` are in the same directory, so I didn't do the
relative paths correctly. The relative paths for the images in
`index.html` are correct now.