### PR TITLE
Fixed uploader bug for new images

### DIFF
--- a/lib/happo/uploader.rb
+++ b/lib/happo/uploader.rb
@@ -41,7 +41,7 @@ module Happo
         image = bucket.objects.build("#{dir}/#{img_name}")
         image.content = open(Happo::Utils.path_to(example[:description],
                                                      example[:viewport],
-                                                     'previous.png'))
+                                                     'current.png'))
         image.content_type = 'image/png'
         image.save
         example[:url] = img_name


### PR DESCRIPTION
Previously, `happo upload_diffs` would throw an error every time
the `previous.png` image for a test could not be found. Thus, if a new
test was defined or if the component didn't change, `happo upload_diffs`
would throw an error. For new images with no `previous.png` or
`diff.png`, the uploader should upload `current.png`.