### PR TITLE
Escape unsafe characters in example descriptions

### DIFF
--- a/lib/happo/uploader.rb
+++ b/lib/happo/uploader.rb
@@ -1,5 +1,6 @@
 require 's3'
 require 'securerandom'
+require 'uri'
 
 module Happo
   class Uploader
@@ -32,7 +33,7 @@ module Happo
                                                      'diff.png'))
         image.content_type = 'image/png'
         image.save
-        diff[:url] = img_name
+        diff[:url] = URI.escape(img_name)
         diff
       end
 
@@ -44,7 +45,7 @@ module Happo
                                                      'current.png'))
         image.content_type = 'image/png'
         image.save
-        example[:url] = img_name
+        example[:url] = URI.escape(img_name)
         example
       end
 


### PR DESCRIPTION
An example description may contain unsafe characters like quotation
marks or other punctuation marks that would break the URL used for the
image source in the generated `index.html`. We need to escape unsafe
characters in example descriptions so that the image source URL always
works correctly in the page displaying diff images and new examples.