### PR TITLE
Get coordinates of all descendants

### DIFF
--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -153,6 +153,50 @@ window.happo = {
     }
   },
 
+  // This function takes a node and a box object that we will mutate.
+  getFullRectRecursive: function(node, box) {
+    var rect = node.getBoundingClientRect();
+
+    box.bottom = Math.max(box.bottom, rect.bottom);
+    box.left = Math.min(box.left, rect.left);
+    box.right = Math.max(box.right, rect.right);
+    box.top = Math.min(box.top, rect.top);
+
+    for (var i = 0; i < node.children.length; i++) {
+      getFullRectRecursive(node.children[i], box);
+    }
+  },
+
+  // This function gets the full size of the given node, including all
+  // descendent nodes. This allows us to ensure that the screenshot includes
+  // absolutely positioned elements. It is important that this is fast, since we
+  // may be iterating over a high number of nodes.
+  getFullRect: function(node) {
+    var rect = node.getBoundingClientRect();
+
+    // Set up the initial object that we will mutate in our recursive function.
+    var box = {
+      bottom: rect.bottom,
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+    };
+
+    // If there are any children, we want to iterate over them recursively,
+    // mutating our box object along the way to expand to include all descendent
+    // nodes.
+    for (var i = 0; i < node.children.length; i++) {
+      getFullRectRecursive(node.children[i], box);
+    }
+
+    // Do width and height calculations at the end, to avoid having to do them
+    // for every node.
+    box.width =  box.right - box.left;
+    box.height =  box.bottom - box.top;
+
+    return box;
+  },
+
   processElem: function(currentExample, elem) {
     try {
       this.currentRenderedElement = elem;
@@ -166,14 +210,9 @@ window.happo = {
           left: 0,
         };
       } else {
-        // We use elem.getBoundingClientRect() instead of offsetTop and its ilk
-        // because elem.getBoundingClientRect() is more accurate and it also
-        // takes CSS transformations and other things of that nature into
-        // account whereas offsetTop and company do not.
-        //
         // Note that this method returns floats, so we need to round those off
         // to integers before returning.
-        rect = elem.getBoundingClientRect();
+        rect = this.getFullRect(elem);
       }
 
       return {


### PR DESCRIPTION
There are some times when you have a component that contains an
absolutely positioned element, or something that has styles that break
out of the layout of the container. In this case, I usually end up
adding a wrapper that has a hard-coded height, to ensure that I am able
to include the entire component in the snapshot, including the
absolutely positioned item. This is not ideal because:

1. I have to know about this quality of the component I am testing.
2. I have to figure out the correct height and hard-code it.
3. If the height of the component changes, my screenshot may end up
   breaking or being less useful.
4. If the component changes to include something like this after the
   fact, screenshots may not catch it.

This commit takes a stab at automating this by recursing through all
descendants and determining a rectangle that includes everything.

I am a little concerned about the possible performance impact of this,
since we need to compute the rectangle of every descendant. For Happo
test suites that have a lot of examples with a lot of nodes in them,
this will add a non-trivial amount of time. Our previous version that
only cared about the rectangle of the container takes 0-1ms. In my very
basic experiments of 100,000 nested empty divs, this method adds
something between 290ms and 700ms on average. In examples with 10,000
nested empty divs, I am seeing ~25ms.

With that in mind, I took extra care to try to write this in an
optimized way. I decided to mutate an object instead of creating a new
one for every node. I also tried to push off as many calculations as
possible so they don't happen inside the recursing loop.

When exploring this, I tried a few other things before landing on the
current implementation. First, I tried
`Array.from(node.children).forEach()` instead of a regular for loop, but
that was slower. I also tried using `window.getComputedStyle(node)` to
determine if it has absolute positioning or something like that before
getting its bounding rectangle, but that was also much slower.

It is possible that an iterative solution would be better than a
recursive solution, especially with very large DOM trees, but I didn't
take the time to try that out.

I considered making this behavior opt-in on a per-example basis, but I
think that the performance is good enough that we don't need to do that.
I believe that the correctness of this solution outweighs any
performance benefits we might see by making this opt-in.

Fixes #104.