### PR TITLE
Include margin of topmost element in dimension calculations

### DIFF
--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -182,6 +182,16 @@ window.happo = {
       top: rect.top,
     };
 
+    // getBoundingClientRect does not include margin, so we need to use
+    // getComputedStyle. Since this is slow and the margin of descendent
+    // elements is significantly less likely to matter, let's include the margin
+    // only from the topmost node.
+    var computedStyle = window.getComputedStyle(node);
+    box.bottom += parseInt(computedStyle.getPropertyValue('margin-bottom'), 10);
+    box.left -= parseInt(computedStyle.getPropertyValue('margin-left'), 10);
+    box.right += parseInt(computedStyle.getPropertyValue('margin-right'), 10);
+    box.top -= parseInt(computedStyle.getPropertyValue('margin-top'), 10);
+
     // If there are any children, we want to iterate over them recursively,
     // mutating our box object along the way to expand to include all descendent
     // nodes.

--- a/spec/happo_spec.rb
+++ b/spec/happo_spec.rb
@@ -141,6 +141,45 @@ describe 'happo' do
     end
   end
 
+  describe 'with margin' do
+    let(:examples_js) { <<-EOS }
+      happo.define('#{description}', function() {
+        var elem = document.createElement('div');
+        elem.style.margin = '10px';
+        elem.innerHTML = 'Foo';
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+    EOS
+
+    it 'exits with a zero exit code' do
+      expect(run_happo[:exit_status]).to eq(0)
+    end
+
+    it 'generates a new current, but no diff' do
+      run_happo
+      expect(snapshot_file_exists?(description, '@large', 'previous.png'))
+        .to eq(false)
+      expect(snapshot_file_exists?(description, '@large', 'diff.png'))
+        .to eq(false)
+      expect(snapshot_file_exists?(description, '@large', 'current.png'))
+        .to eq(true)
+      expect(
+        YAML.load(File.read(File.join(
+          @tmp_dir, 'snapshots', 'result_summary.yaml')))
+      ).to eq(
+        new_examples: [
+          {
+            description: description,
+            viewport: 'large'
+          }
+        ],
+        diff_examples: [],
+        okay_examples: []
+      )
+    end
+  end
+
   describe 'with a previous run' do
     context 'and no diff' do
       before do


### PR DESCRIPTION
We currently recurse through the DOM tree using
`getBoundingClientRect()` to determine the shape of the box that we want
to take a screenshot of. This is working well, except when the topmost
element has margin on it, since `getBoundingClientRect()` does not
include margin. This means that you might miss some important details
about the visual appearance of your component if you aren't being super
careful.

I think we should use `getComputedStyle()` to determine the margin of
the topmost element and use that in our rectangle dimension
calculations. I want to avoid doing this for every node in the tree,
since it is not very fast. I think doing this on the topmost element
will likely get us 99% of the benefit, so it seems like an easy win.

Fixes #108.

cc: @serena-w 