### PR TITLE
Fix snapshots that expand the top/left of the screen

### DIFF
--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -162,6 +162,14 @@ window.happo = {
     box.right = Math.max(box.right, rect.right);
     box.top = Math.min(box.top, rect.top);
 
+    if (box.left < 0) {
+      box.left = 0; // Don't go outside window
+    }
+
+    if (box.top < 0) {
+      box.top = 0; // Don't go outside window
+    }
+
     for (var i = 0; i < node.children.length; i++) {
       this.getFullRectRecursive(node.children[i], box);
     }

--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -162,14 +162,6 @@ window.happo = {
     box.right = Math.max(box.right, rect.right);
     box.top = Math.min(box.top, rect.top);
 
-    if (box.left < 0) {
-      box.left = 0; // Don't go outside window
-    }
-
-    if (box.top < 0) {
-      box.top = 0; // Don't go outside window
-    }
-
     for (var i = 0; i < node.children.length; i++) {
       this.getFullRectRecursive(node.children[i], box);
     }
@@ -206,6 +198,11 @@ window.happo = {
     for (var i = 0; i < node.children.length; i++) {
       this.getFullRectRecursive(node.children[i], box);
     }
+
+    // Cut off things that render off the screen to the top or left, since those
+    // won't be in the screenshot file that we then crop from.
+    box.left = Math.max(box.left, 0);
+    box.top = Math.max(box.top, 0);
 
     // Do width and height calculations at the end, to avoid having to do them
     // for every node.

--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -199,13 +199,16 @@ window.happo = {
       this.getFullRectRecursive(node.children[i], box);
     }
 
-    // Cut off things that render off the screen to the top or left, since those
-    // won't be in the screenshot file that we then crop from.
+    // As the last step, we calculate the width and height for the box. This is
+    // to avoid having to do them for every node. Before we do that however, we
+    // cut off things that render off the screen to the top or left, since those
+    // won't be in the screenshot file that we then crop from. If you're
+    // wondering why right and bottom isn't "fixed" here too, it's because we
+    // don't have to since the screenshot already includes overflowing content
+    // on the bottom and right.
     box.left = Math.max(box.left, 0);
     box.top = Math.max(box.top, 0);
 
-    // Do width and height calculations at the end, to avoid having to do them
-    // for every node.
     box.width =  box.right - box.left;
     box.height =  box.bottom - box.top;
 

--- a/spec/happo_spec.rb
+++ b/spec/happo_spec.rb
@@ -180,6 +180,22 @@ describe 'happo' do
     end
   end
 
+  describe 'with an element rendered outside the screen' do
+    let(:examples_js) { <<-EOS }
+      happo.define('#{description}', function() {
+        var elem = document.createElement('div');
+        elem.style.margin = '-5px';
+        elem.innerHTML = 'Foo';
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+    EOS
+
+    it 'exits with a zero exit code' do
+      expect(run_happo[:exit_status]).to eq(0)
+    end
+  end
+
   describe 'with a previous run' do
     context 'and no diff' do
       before do


### PR DESCRIPTION
In the brigade codebase, we have a component that renders 1px outside
the screen. The recent code we've added to improve the detection of the
box wasn't taking into account that elements might render off-screen.

Adding a simple check to see if either top or left is negative fixes the
issue. I didn't address this for elements that expand right or bottom of
the screen as I think the screenshotting process already handles those
(by including the content).