### PR TITLE
Add way to demo the review page, improve review page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,118 @@
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/Void:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 100
+
+Metrics/MethodLength:
+  Max: 20
+
+Metrics/ModuleLength:
+  Enabled: false
+
+# Enforcing this results in a lot of unnecessary indentation.
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/ClosingParenthesisIndentation:
+  Enabled: false
+
+Style/Documentation:
+  Exclude:
+    - 'spec/overcommit/**/*'
+
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+Style/Encoding:
+  EnforcedStyle: when_needed
+
+Style/FileName:
+  Exclude:
+    - 'template-dir/hooks/*'
+    - 'Gemfile'
+    - 'Rakefile'
+    - '*.gemspec'
+
+Style/FirstParameterIndentation:
+  Enabled: false
+
+Style/FormatString:
+  Enabled: false
+
+# There are a number of situations where this makes code less readable or
+# disrupts the visual flow of code.
+Style/GuardClause:
+  Enabled: false
+
+Style/IndentArray:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+# We want to allow multi-line lambdas using the `->` syntax which Rubocop
+# doesn't allow. We're also not too worried about people using `lambda` for
+# single-line lambdas either.
+Style/Lambda:
+  Enabled: false
+
+Style/MultilineMethodCallIndentation:
+  Enabled: false
+
+Style/MultilineOperationIndentation:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/ParallelAssignment:
+  Enabled: false
+
+# Prefer curly braces except for %i/%w/%W, since those return arrays.
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%': '{}'
+    '%i': '[]'
+    '%q': '{}'
+    '%Q': '{}'
+    '%r': '{}'
+    '%s': '()'
+    '%w': '[]'
+    '%W': '[]'
+    '%x': '{}'
+
+# Renaming `has_something?` to `something?` obfuscates whether it is a "is-a" or
+# a "has-a" relationship.
+Style/PredicateName:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+# Forcing a particular name (e.g. |a, e|) for inject methods prevents you from
+# choosing intention-revealing names.
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/SpaceBeforeFirstArg:
+  Exclude:
+    - '*.gemspec'
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false

--- a/lib/happo/public/happo-styles.css
+++ b/lib/happo/public/happo-styles.css
@@ -24,7 +24,7 @@ body {
 .header {
   align-items: baseline;
   background-color: #ffffff;
-  border-bottom: 1px solid #cccccc;
+  box-shadow: 0 0 4px rgba(0, 0, 0, .3);
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;

--- a/lib/happo/server.rb
+++ b/lib/happo/server.rb
@@ -87,6 +87,11 @@ module Happo
           viewport: 'large',
           url: 'http://placehold.it/850x150',
         },
+        {
+          description: '<SomethingElseNew>',
+          viewport: 'small',
+          url: 'http://placehold.it/350x150',
+        },
       ]
 
       erb :diffs, locals: {

--- a/lib/happo/server.rb
+++ b/lib/happo/server.rb
@@ -52,6 +52,49 @@ module Happo
       }
     end
 
+    get '/review-demo' do
+      diff_images = [
+        {
+          description: 'First component',
+          viewport: 'small',
+          url: 'http://placehold.it/350x150',
+        },
+        {
+          description: 'First component',
+          viewport: 'medium',
+          url: 'http://placehold.it/550x150',
+        },
+        {
+          description: 'First component',
+          viewport: 'large',
+          url: 'http://placehold.it/850x150',
+        },
+      ]
+
+      new_images = [
+        {
+          description: 'New component',
+          viewport: 'small',
+          url: 'http://placehold.it/350x150',
+        },
+        {
+          description: 'New component',
+          viewport: 'medium',
+          url: 'http://placehold.it/550x150',
+        },
+        {
+          description: 'New component',
+          viewport: 'large',
+          url: 'http://placehold.it/850x150',
+        },
+      ]
+
+      erb :diffs, locals: {
+        diff_images: diff_images,
+        new_images: new_images
+      }
+    end
+
     get '/resource' do
       file = params[:file]
       if file.start_with? 'http'

--- a/lib/happo/server.rb
+++ b/lib/happo/server.rb
@@ -55,17 +55,17 @@ module Happo
     get '/review-demo' do
       diff_images = [
         {
-          description: 'First component',
+          description: '<First> with "test"',
           viewport: 'small',
           url: 'http://placehold.it/350x150',
         },
         {
-          description: 'First component',
+          description: '<First> some other \'test\'',
           viewport: 'medium',
           url: 'http://placehold.it/550x150',
         },
         {
-          description: 'First component',
+          description: '<First>',
           viewport: 'large',
           url: 'http://placehold.it/850x150',
         },
@@ -73,17 +73,17 @@ module Happo
 
       new_images = [
         {
-          description: 'New component',
+          description: '<New>',
           viewport: 'small',
           url: 'http://placehold.it/350x150',
         },
         {
-          description: 'New component',
+          description: '<New>',
           viewport: 'medium',
           url: 'http://placehold.it/550x150',
         },
         {
-          description: 'New component',
+          description: '<New>',
           viewport: 'large',
           url: 'http://placehold.it/850x150',
         },

--- a/lib/happo/utils.rb
+++ b/lib/happo/utils.rb
@@ -61,6 +61,26 @@ module Happo
                       query: query).to_s
     end
 
+    def self.pluralize(count, singular, plural)
+      if count == 1
+        "#{count} #{singular}"
+      else
+        "#{count} #{plural}"
+      end
+    end
+
+    def self.page_title(diff_images, new_images)
+      title = []
+
+      unless diff_images.count == 0
+        title << pluralize(diff_images.count, 'diff', 'diffs')
+      end
+
+      title << "#{new_images.count} new" unless new_images.count == 0
+
+      "#{title.join(', ')} · Happo"
+    end
+
     def self.favicon_as_base64
       favicon = File.expand_path('../public/favicon.ico', __FILE__)
       "data:image/ico;base64,#{Base64.encode64(File.binread(favicon))}"

--- a/lib/happo/utils.rb
+++ b/lib/happo/utils.rb
@@ -32,7 +32,11 @@ module Happo
 
     def self.config_from_file
       config_file_name = ENV['HAPPO_CONFIG_FILE'] || '.happo.yaml'
-      YAML.load(ERB.new(File.read(config_file_name)).result)
+      if File.exist?(config_file_name)
+        YAML.load(ERB.new(File.read(config_file_name)).result)
+      else
+        {}
+      end
     end
 
     def self.normalize_description(description)

--- a/lib/happo/utils.rb
+++ b/lib/happo/utils.rb
@@ -95,18 +95,17 @@ module Happo
         self.config['snapshots_folder'], 'result_summary.yaml')))
     end
 
-    def self.to_slug(string)
+    def self.to_inline_slug(string)
       value = string.gsub(/[^\x00-\x7F]/n, '').to_s
       value.gsub!(/[']+/, '')
       value.gsub!(/\W+/, ' ')
       value.strip!
-      value.downcase!
       value.tr!(' ', '-')
-      value
+      URI.escape(value)
     end
 
     def self.image_slug(diff_image)
-      to_slug("#{diff_image[:description]} #{diff_image[:viewport]}")
+      to_inline_slug("#{diff_image[:description]} #{diff_image[:viewport]}")
     end
   end
 end

--- a/lib/happo/utils.rb
+++ b/lib/happo/utils.rb
@@ -94,5 +94,19 @@ module Happo
       YAML.load(File.read(File.join(
         self.config['snapshots_folder'], 'result_summary.yaml')))
     end
+
+    def self.to_slug(string)
+      value = string.gsub(/[^\x00-\x7F]/n, '').to_s
+      value.gsub!(/[']+/, '')
+      value.gsub!(/\W+/, ' ')
+      value.strip!
+      value.downcase!
+      value.tr!(' ', '-')
+      value
+    end
+
+    def self.image_slug(diff_image)
+      to_slug("#{diff_image[:description]} #{diff_image[:viewport]}")
+    end
   end
 end

--- a/lib/happo/views/diffs.erb
+++ b/lib/happo/views/diffs.erb
@@ -20,21 +20,35 @@
 
     <main class="main">
       <% if diff_images.count > 0%>
-        <h2>Diffs (<%= diff_images.count %>)</h2>
-        <% diff_images.each do |diff| %>
-          <h3>
-            <%= Rack::Utils.escape_html(diff[:description]) %> @ <%= diff[:viewport] %>
+        <h2 id="diffs">
+          <a href="#diffs">
+            Diffs (<%= diff_images.count %>)
+          </a>
+        </h2>
+
+        <% diff_images.each do |image| %>
+          <h3 id="<%= Happo::Utils.image_slug(image) %>">
+            <a href="#<%= Happo::Utils.image_slug(image) %>">
+              <%= Rack::Utils.escape_html(image[:description]) %> @ <%= image[:viewport] %>
+            </a>
           </h3>
 
-          <img src="<%= diff[:url] %>">
+          <img src="<%= image[:url] %>">
         <% end %>
       <% end %>
 
       <% if new_images.count > 0%>
-        <h2>New examples (<%= new_images.count %>)</h2>
+        <h2 id="new">
+          <a href="#new">
+            New examples (<%= new_images.count %>)
+          </a>
+        </h2>
+
         <% new_images.each do |image| %>
-          <h3>
-            <%= Rack::Utils.escape_html(image[:description]) %> @ <%= image[:viewport] %>
+          <h3 id="<%= Happo::Utils.image_slug(image) %>">
+            <a href="#<%= Happo::Utils.image_slug(image) %>">
+              <%= Rack::Utils.escape_html(image[:description]) %> @ <%= image[:viewport] %>
+            </a>
           </h3>
 
           <img src="<%= image[:url] %>">

--- a/lib/happo/views/diffs.erb
+++ b/lib/happo/views/diffs.erb
@@ -14,7 +14,9 @@
 
   <body>
     <header class="header">
-      <h1 class="header_title">Happo diffs</h1>
+      <h1 class="header_title">
+        <%= Happo::Utils.page_title(diff_images, new_images) %>
+      </h1>
       <div class="header__time">Generated: <%= Time.now %></div>
     </header>
 

--- a/lib/happo/views/diffs.erb
+++ b/lib/happo/views/diffs.erb
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Happo diffs</title>
+    <title><%= Happo::Utils.page_title(diff_images, new_images) %></title>
 
     <link rel="shortcut icon" href="<%= Happo::Utils.favicon_as_base64 %>" />
 

--- a/lib/happo/views/diffs.erb
+++ b/lib/happo/views/diffs.erb
@@ -19,22 +19,26 @@
     </header>
 
     <main class="main">
-      <h2>Diffs (<%= diff_images.count %>)</h2>
-      <% diff_images.each do |diff| %>
-        <h3>
-          <%= Rack::Utils.escape_html(diff[:description]) %> @ <%= diff[:viewport] %>
-        </h3>
-        <p><img src="<%= diff[:url] %>"></p>
+      <% if diff_images.count > 0%>
+        <h2>Diffs (<%= diff_images.count %>)</h2>
+        <% diff_images.each do |diff| %>
+          <h3>
+            <%= Rack::Utils.escape_html(diff[:description]) %> @ <%= diff[:viewport] %>
+          </h3>
+
+          <img src="<%= diff[:url] %>">
+        <% end %>
       <% end %>
 
-      <hr>
+      <% if new_images.count > 0%>
+        <h2>New examples (<%= new_images.count %>)</h2>
+        <% new_images.each do |image| %>
+          <h3>
+            <%= Rack::Utils.escape_html(image[:description]) %> @ <%= image[:viewport] %>
+          </h3>
 
-      <h2>New examples (<%= new_images.count %>)</h2>
-      <% new_images.each do |image| %>
-        <h3>
-          <%= Rack::Utils.escape_html(image[:description]) %> @ <%= image[:viewport] %>
-        </h3>
-        <p><img src="<%= image[:url] %>"></p>
+          <img src="<%= image[:url] %>">
+        <% end %>
       <% end %>
     </main>
   </body>

--- a/review-demo.rb
+++ b/review-demo.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+# Add the lib directory to Ruby's load path so our requires will work.
+$:.unshift(File.expand_path('./lib'))
+
+require 'happo'
+
+system 'open', Happo::Utils.construct_url('/review-demo')
+require 'happo/server'


### PR DESCRIPTION
We want to vastly improve the diffs page, but that is slow going because
we don't have a super easy way to preview our changes. This commit fixes
this by adding a review-demo.rb script that starts up a server with some
dummy data in it so we can see what a diffs page might look like. This
should make it easier to improve this page.

Fixes #103