### PR TITLE
Add meta charset utf-8 to all pages

### DIFF
--- a/lib/happo/views/debug.erb
+++ b/lib/happo/views/debug.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <title>Happo Debug Tool</title>
 
     <link rel="shortcut icon" href="<%= Happo::Utils.favicon_as_base64 %>" />

--- a/lib/happo/views/diffs.erb
+++ b/lib/happo/views/diffs.erb
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <title><%= Happo::Utils.page_title(diff_images, new_images) %></title>
 
     <link rel="shortcut icon" href="<%= Happo::Utils.favicon_as_base64 %>" />

--- a/lib/happo/views/index.erb
+++ b/lib/happo/views/index.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <title>Happo</title>
 
     <link rel="shortcut icon" href="<%= Happo::Utils.favicon_as_base64 %>" />


### PR DESCRIPTION
We are currently seeing a weird encoding issue on the uploaded diffs
page. I'm not sure if this will resolve that, but it is the right thing
to do and it might help.

Addresses #121