### PR TITLE
Set content-encoding to utf-8 on uploaded HTML

### DIFF
--- a/lib/happo/uploader.rb
+++ b/lib/happo/uploader.rb
@@ -52,6 +52,7 @@ module Happo
       path = File.expand_path(
         File.join(File.dirname(__FILE__), 'views', 'diffs.erb'))
       html.content = ERB.new(File.read(path)).result(binding)
+      html.content_encoding = 'utf-8'
       html.content_type = 'text/html'
       html.save
       html.url


### PR DESCRIPTION
We are seeing encoding issues on the HTML we upload to S3. Although I am
not able to find any good documentation on this, I believe that we can
set the content-encoding like this.

Relevant source code:

https://github.com/qoobaa/s3/blob/29363972/lib/s3/object.rb#L8

Probably fixes #121