### PR TITLE
Make image swiping work for all image sizes

### DIFF
--- a/lib/happo/public/happo-styles.css
+++ b/lib/happo/public/happo-styles.css
@@ -87,16 +87,15 @@ body {
 }
 
 .Swiper {
-  background-repeat: no-repeat;
-  background-position: top left;
   display: inline-block;
-  position: relative;
   line-height: 0;
+  position: relative;
 }
 
 .Swiper__cursor {
   box-shadow: 0px 0px 2px 0px #ffffff;
   position: absolute;
+  left: 0;
   top: 0;
   width: 1px;
   height: 100%;
@@ -105,7 +104,11 @@ body {
 }
 
 .Swiper__image {
+  left: 0;
+  overflow: hidden;
   pointer-events: none;
+  position: absolute;
+  top: 0;
 }
 
 .SideBySide__image {


### PR DESCRIPTION
Our first pass at this didn't show the entire image if the previous
image was larger than the current image. I decided to fix this by
taking an alternate approach that uses containers with hidden
overflow. This gives us more control over how these elements behave.

Since this technique uses translateX, which uses percentages based off
the element instead of the container, I needed to switch the cursor
left position from being a percentage to being an absolute number.