### PR TITLE
Disable nested scrollbars before taking screenshots

### DIFF
--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -162,8 +162,27 @@ window.happo = {
     }
   },
 
+  // Scrollbars inside of elements may cause spurious visual diffs. To avoid
+  // this issue, we can hide them automatically by styling the overflow to be
+  // hidden.
+  removeScrollbars: function removeScrollbars(node) {
+    if (
+      node.scrollHeight !== node.clientHeight
+      || node.scrollWidth !== node.clientWidth
+    ) {
+      // We style this via node.style.cssText so that we can override any styles
+      // that might already be `!important`.
+      // eslint-disable-next-line no-param-reassign
+      node.style.cssText += 'overflow: hidden !important';
+    }
+  },
+
   // This function takes a node and a box object that we will mutate.
   getFullRectRecursive: function getFullRectRecursive(node, box) {
+    // Since we are already traversing through every node, let's piggyback on
+    // that work and remove scrollbars to prevent spurious diffs.
+    this.removeScrollbars(node);
+
     var rect = node.getBoundingClientRect();
 
     /* eslint-disable no-param-reassign */
@@ -183,6 +202,8 @@ window.happo = {
   // absolutely positioned elements. It is important that this is fast, since we
   // may be iterating over a high number of nodes.
   getFullRect: function getFullRect(node) {
+    this.removeScrollbars(node);
+
     var rect = node.getBoundingClientRect();
 
     // Set up the initial object that we will mutate in our recursive function.

--- a/spec/happo_spec.rb
+++ b/spec/happo_spec.rb
@@ -141,6 +141,51 @@ describe 'happo' do
     end
   end
 
+  describe 'with an element that has a scrollbar' do
+    let(:examples_js) { <<-EOS }
+      happo.define('#{description}', function() {
+        var elem = document.createElement('div');
+        elem.style.overflow = 'scroll';
+        elem.style.height = '100px';
+
+        var nested = document.createElement('div');
+        nested.innerHTML = 'Foo';
+        nested.style.height = '500%';
+        elem.appendChild(nested);
+
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+    EOS
+
+    it 'exits with a zero exit code' do
+      expect(run_happo[:exit_status]).to eq(0)
+    end
+
+    it 'generates a new current, but no diff' do
+      run_happo
+      expect(snapshot_file_exists?(description, '@large', 'previous.png'))
+        .to eq(false)
+      expect(snapshot_file_exists?(description, '@large', 'diff.png'))
+        .to eq(false)
+      expect(snapshot_file_exists?(description, '@large', 'current.png'))
+        .to eq(true)
+      expect(
+        YAML.load(File.read(File.join(
+          @tmp_dir, 'snapshots', 'result_summary.yaml')))
+      ).to eq(
+        new_examples: [
+          {
+            description: description,
+            viewport: 'large'
+          }
+        ],
+        diff_examples: [],
+        okay_examples: []
+      )
+    end
+  end
+
   describe 'with margin' do
     let(:examples_js) { <<-EOS }
       happo.define('#{description}', function() {


### PR DESCRIPTION
I have a component that adds its own scrollable container within the
document. This causes the scrollbar to be part of the component, and
therefore, part of the screenshot. For some reason, the scrollbar is
sometimes a slightly different color, which causes a spurious diff.
This is in Travis CI.

I'm not entirely sure why the scrollbar is sometimes different.
Regardless, I don't think it is all that useful to have the scrollbar as
part of the screenshot.

I came up with the idea to check each node and see if it has a scrollbar
by comparing the scroll dimensions to the client dimensions. If it does,
we simply re-style the node to be `overflow: hidden`. In a
proof-of-concept with 10,000 nodes, adding this check to the traversal
and bounding client rectangle check adds essentially no extra time,
which sounds good to me.

One downside to this approach is that if we want to run visual
regression testing on different browsers and platforms, it can be useful
to see that there is a scrollbar sometimes, because that can affect the
widths of elements, which may affect how things flow or line up. I'm
going to not worry about this for now though since we aren't very close
to being in this world anyway.

I believe that this fixes #131.

I am also using Aphrodite in a project which adds styles to the head
that all include `!important`. This works well, except it overrides our
animation-disabling overrides. I think if this scrollbar fix is
successful, we might want to apply the same technique to animations.