### PR TITLE
Include all nodes in screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ happo.define('button', function() {
   elem.setAttribute('class', '.button');
   elem.innerHTML = 'Submit';
   document.body.appendChild(elem);
-  return elem;
 });
 ```
 
@@ -56,31 +55,13 @@ happo.define('responsive component', function() {
   var elem = document.createElement('div');
   elem.setAttribute('class', '.responsive-component');
   document.body.appendChild(elem);
-  return elem;
 }, { viewports: ['large', 'small'] });
-```
-
-### Controlling the snapshot
-
-Happo can usually figure out what part of the screen belongs to your
-component, and take the snapshot of that area. In some situations however, that
-won't work. In those cases, you can pass in the `snapshotEntireScreen` option
-to force a full-size snapshot to be taken.
-
-```javascript
-happo.define('dialog window', function() {
-  var elem = document.createElement('div');
-  elem.setAttribute('class', '.dialog');
-  document.body.appendChild(elem);
-  return elem;
-}, { snapshotEntireScreen: true });
 ```
 
 ### Async examples
 
 If your examples need to do something asynchronous before they finish render,
-you can return a `Promise` from your define method that resolves with the
-element.
+you can return a `Promise` from your define method.
 
 ```javascript
 happo.define('async component', function() {
@@ -89,7 +70,7 @@ happo.define('async component', function() {
     document.body.appendChild(elem);
     setTimeout(function() {
       elem.innerHTML = 'Async content loaded';
-      resolve(elem);
+      resolve();
     }, 100);
   });
 });
@@ -103,7 +84,7 @@ happo.define('async component', function(done) {
   document.body.appendChild(elem);
   setTimeout(function() {
     elem.innerHTML = 'Async content loaded';
-    done(elem);
+    done();
   }, 100);
 });
 ```

--- a/example-project/example.js
+++ b/example-project/example.js
@@ -3,19 +3,16 @@ happo.define('foo', function() {
   elem.setAttribute('class', 'foo');
   elem.innerHTML = 'Texts insides';
   document.body.appendChild(elem);
-  return elem;
 });
 
 happo.define('hallooo', function() {
   var elem = document.createElement('span');
   elem.innerHTML = 'Hioyi!<br>Hello';
   document.body.appendChild(elem);
-  return elem;
 }, { viewports: ['mobile', 'desktop'] });
 
 happo.define('bar', function() {
   var elem = document.createElement('span');
   elem.innerHTML = 'go bars!<br>bars';
   document.body.appendChild(elem);
-  return elem;
-}, { snapshotEntireScreen: true });
+});

--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -10,7 +10,6 @@
 window.happo = {
   defined: {},
   fdefined: [],
-  currentRenderedElement: undefined,
   errors: [],
 
   define: function define(description, func, options) {
@@ -99,8 +98,7 @@ window.happo = {
    *
    * @param {Object} renderedElement
    */
-  cleanOutElement: function cleanOutElement(renderedElement) {
-    renderedElement.parentNode.removeChild(renderedElement);
+  cleanOutElement: function cleanOutElement() {
   },
 
   /**
@@ -121,10 +119,8 @@ window.happo = {
       }
 
       // Clear out the body of the document
-      if (this.currentRenderedElement) {
-        this.cleanOutElement(this.currentRenderedElement);
-      }
       while (document.body.firstChild) {
+        this.cleanOutElement(document.body.firstChild);
         document.body.removeChild(document.body.firstChild);
       }
 
@@ -133,8 +129,8 @@ window.happo = {
         // The function takes an argument, which is a callback that is called
         // once it is done executing. This can be used to write functions that
         // have asynchronous code in them.
-        this.tryAsync(func).then(function (elem) {
-          doneFunc(this.processElem(currentExample, elem));
+        this.tryAsync(func).then(function () {
+          doneFunc(this.processExample(currentExample));
         }.bind(this)).catch(function (error) {
           doneFunc(this.handleError(currentExample, error));
         }.bind(this));
@@ -146,15 +142,15 @@ window.happo = {
         if (result instanceof Promise) {
           // The function returned a promise, so we need to wait for it to
           // resolve before proceeding.
-          result.then(function (elem) {
-            doneFunc(this.processElem(currentExample, elem));
+          result.then(function () {
+            doneFunc(this.processExample(currentExample));
           }.bind(this)).catch(function (error) {
             doneFunc(this.handleError(currentExample, error));
           }.bind(this));
         } else {
           // The function did not return a promise, so we assume it gave us an
           // element that we can process immediately.
-          doneFunc(this.processElem(currentExample, result));
+          doneFunc(this.processExample(currentExample));
         }
       }
     } catch (error) {
@@ -197,38 +193,36 @@ window.happo = {
     }
   },
 
-  // This function gets the full size of the given node, including all
-  // descendent nodes. This allows us to ensure that the screenshot includes
-  // absolutely positioned elements. It is important that this is fast, since we
-  // may be iterating over a high number of nodes.
-  getFullRect: function getFullRect(node) {
-    this.removeScrollbars(node);
-
-    var rect = node.getBoundingClientRect();
-
+  // This function gets the full size of children in the document body,
+  // including all descendent nodes. This allows us to ensure that the
+  // screenshot includes absolutely positioned elements. It is important that
+  // this is fast, since we may be iterating over a high number of nodes.
+  getFullRect: function getFullRect() {
     // Set up the initial object that we will mutate in our recursive function.
     var box = {
-      bottom: rect.bottom,
-      left: rect.left,
-      right: rect.right,
-      top: rect.top,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      top: 0,
     };
-
-    // getBoundingClientRect does not include margin, so we need to use
-    // getComputedStyle. Since this is slow and the margin of descendent
-    // elements is significantly less likely to matter, let's include the margin
-    // only from the topmost node.
-    var computedStyle = window.getComputedStyle(node);
-    box.bottom += parseInt(computedStyle.getPropertyValue('margin-bottom'), 10);
-    box.left -= parseInt(computedStyle.getPropertyValue('margin-left'), 10);
-    box.right += parseInt(computedStyle.getPropertyValue('margin-right'), 10);
-    box.top -= parseInt(computedStyle.getPropertyValue('margin-top'), 10);
 
     // If there are any children, we want to iterate over them recursively,
     // mutating our box object along the way to expand to include all descendent
     // nodes.
-    for (var i = 0; i < node.children.length; i++) {
-      this.getFullRectRecursive(node.children[i], box);
+    for (var i = 0; i < document.body.children.length; i++) {
+      var node = document.body.children[i];
+
+      this.getFullRectRecursive(node, box);
+
+      // getBoundingClientRect does not include margin, so we need to use
+      // getComputedStyle. Since this is slow and the margin of descendent
+      // elements is significantly less likely to matter, let's include the
+      // margin only from the topmost nodes.
+      var computedStyle = window.getComputedStyle(node);
+      box.bottom += parseInt(computedStyle.getPropertyValue('margin-bottom'), 10);
+      box.left -= parseInt(computedStyle.getPropertyValue('margin-left'), 10);
+      box.right += parseInt(computedStyle.getPropertyValue('margin-right'), 10);
+      box.top -= parseInt(computedStyle.getPropertyValue('margin-top'), 10);
     }
 
     // As the last step, we calculate the width and height for the box. This is
@@ -247,23 +241,11 @@ window.happo = {
     return box;
   },
 
-  processElem: function processElem(currentExample, elem) {
+  processExample: function processExample(currentExample) {
     try {
-      this.currentRenderedElement = elem;
-
-      var rect;
-      if (currentExample.options.snapshotEntireScreen) {
-        rect = {
-          width: window.innerWidth,
-          height: window.innerHeight,
-          top: 0,
-          left: 0,
-        };
-      } else {
-        // Note that this method returns floats, so we need to round those off
-        // to integers before returning.
-        rect = this.getFullRect(elem);
-      }
+      // Note that this method returns floats, so we need to round those off
+      // to integers before returning.
+      var rect = this.getFullRect();
 
       return {
         description: currentExample.description,


### PR DESCRIPTION
I've been looking into a case where we get spurious diffs on a scrollbar
added to an element. In 239611300f I added some code that disabled
scrollbars on nested elements, but this didn't work for my particular
case.

After looking at this more closely for this case, I have determined that
this is happening because this component happens to use a portal to
render its contents in a different node. In this case, we are using the
`snapshotEntireScreen` option to take a screenshot of the whole screen.
Not only does this bypass the entire code tree that has the scrollbar
disabling logic in it, it also wouldn't work with that logic because
that only affects nodes within the tree starting with the node returned
by the example--but in this case, all of the DOM nodes are outside of
that tree.

I think a good way to solve this would be to change how Happo works a
little. Right now each example has to return a reference to a DOM node,
which doesn't work so well for things that render in two parts of the
DOM (e.g "portals" in React apps). Instead of doing this, I think we
should use our `getFullRect` routine on all of the nodes in
`document.body`. This would likely work for every case, simplify the
API, and allow us to remove the `snapshotEntireScreen` option.

Fixes #131.