### PR TITLE
Allow async done callback to take no arguments

### DIFF
--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -72,18 +72,9 @@ window.happo = {
       }, 3000);
 
       // This function is called by the example when it is done executing.
-      var doneCallback = function doneCallback(elem) {
+      var doneCallback = function doneCallback() {
         clearTimeout(timeout);
-
-        if (!arguments.length) {
-          reject(new Error(
-            'The async done callback expects the rendered element as an ' +
-            'argument, but there were no arguments.'
-          ));
-          return;
-        }
-
-        resolve(elem);
+        resolve();
       };
 
       func(doneCallback);

--- a/spec/happo_spec.rb
+++ b/spec/happo_spec.rb
@@ -487,7 +487,7 @@ describe 'happo' do
           var elem = document.createElement('div');
           elem.innerHTML = 'Foo';
           document.body.appendChild(elem);
-          done(elem);
+          done();
         });
       }, #{example_config});
     EOS
@@ -531,7 +531,7 @@ describe 'happo' do
                     var elem = document.createElement('div');
                     elem.innerHTML = 'Football';
                     document.body.appendChild(elem);
-                    done(elem);
+                    done();
                   });
                 }, #{example_config});
               EOS
@@ -605,7 +605,7 @@ describe 'happo' do
                     var elem = document.createElement('div');
                     elem.innerHTML = 'Jon Snow';
                     document.body.appendChild(elem);
-                    done(elem);
+                    done();
                   });
                 }, #{example_config});
               EOS


### PR DESCRIPTION
In 5428434cc1f we changed Happo to include all nodes in screenshots.
This means that the async done callback doesn't need to take any
arguments. However, we still had some code here enforcing this.