### PR TITLE
Improve scrollbar-prevention

### DIFF
--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -151,13 +151,29 @@ window.happo = {
     }
   },
 
+  isAutoOrScroll: function isAutoOrScroll(overflow) {
+    return overflow === 'auto' || overflow === 'scroll';
+  },
+
   // Scrollbars inside of elements may cause spurious visual diffs. To avoid
   // this issue, we can hide them automatically by styling the overflow to be
   // hidden.
   removeScrollbars: function removeScrollbars(node) {
-    if (
+    var isOverflowing =
       node.scrollHeight !== node.clientHeight
-      || node.scrollWidth !== node.clientWidth
+      || node.scrollWidth !== node.clientWidth;
+
+    if (!isOverflowing) {
+      // This node has no overflowing content. We're returning early to prevent
+      // calling getComputedStyle down below (which is an expensive operation).
+      return;
+    }
+
+    var style = window.getComputedStyle(node);
+    if (
+      this.isAutoOrScroll(style.getPropertyValue('overflow-y'))
+      || this.isAutoOrScroll(style.getPropertyValue('overflow-x'))
+      || this.isAutoOrScroll(style.getPropertyValue('overflow'))
     ) {
       // We style this via node.style.cssText so that we can override any styles
       // that might already be `!important`.


### PR DESCRIPTION
After upgrading to 2.7.3 (from 2.5), we're seeing a bunch of mysterious
diffs coming from the code that is meant to prevent scrollbars.

[Fixes #146]
[Fixes #145]

Instead of applying `overflow: hidden` whenever we notice something
overflowing, we now also check to see that there's an `overflow: auto`
or `overflow: scroll` present. This check is a bit expensive, but if we
can do it only in cases of actual content overflow we're mostly
protected from performance issues.