### PR TITLE
Improve screenshotting of components with sub-pixel dimensions

### DIFF
--- a/lib/happo/public/happo-runner.js
+++ b/lib/happo/public/happo-runner.js
@@ -251,11 +251,19 @@ window.happo = {
       // elements is significantly less likely to matter, let's include the
       // margin only from the topmost nodes.
       var computedStyle = window.getComputedStyle(node);
-      box.bottom += parseInt(computedStyle.getPropertyValue('margin-bottom'), 10);
-      box.left -= parseInt(computedStyle.getPropertyValue('margin-left'), 10);
-      box.right += parseInt(computedStyle.getPropertyValue('margin-right'), 10);
-      box.top -= parseInt(computedStyle.getPropertyValue('margin-top'), 10);
+      box.bottom += parseFloat(computedStyle.getPropertyValue('margin-bottom'));
+      box.left -= parseFloat(computedStyle.getPropertyValue('margin-left'));
+      box.right += parseFloat(computedStyle.getPropertyValue('margin-right'));
+      box.top -= parseFloat(computedStyle.getPropertyValue('margin-top'));
     }
+
+    // Since getBoundingClientRect() and margins can contain subpixel values, we
+    // want to round everything before calculating the width and height to
+    // ensure that we will take a screenshot of the entire component.
+    box.bottom = Math.ceil(box.bottom);
+    box.left = Math.floor(box.left);
+    box.right = Math.ceil(box.right);
+    box.top = Math.floor(box.top);
 
     // As the last step, we calculate the width and height for the box. This is
     // to avoid having to do them for every node. Before we do that however, we
@@ -275,16 +283,14 @@ window.happo = {
 
   processExample: function processExample(currentExample) {
     try {
-      // Note that this method returns floats, so we need to round those off
-      // to integers before returning.
       var rect = this.getFullRect();
 
       return {
         description: currentExample.description,
-        width: Math.ceil(rect.width),
-        height: Math.ceil(rect.height),
-        top: Math.floor(rect.top),
-        left: Math.floor(rect.left),
+        width: rect.width,
+        height: rect.height,
+        top: rect.top,
+        left: rect.left,
       };
     } catch (error) {
       return this.handleError(currentExample, error);

--- a/spec/happo_spec.rb
+++ b/spec/happo_spec.rb
@@ -169,6 +169,31 @@ describe 'happo' do
     end
   end
 
+  describe 'with sub-pixel values' do
+    let(:examples_js) { <<-EOS }
+      happo.define('#{description}', function() {
+        var elem = document.createElement('div');
+        elem.innerHTML = 'Foo';
+
+        elem.style.height = '20.1px';
+        elem.style.left = '11.1px';
+        elem.style.position = 'relative';
+        elem.style.top = '10.1px';
+        elem.style.width = '30.1px';
+
+        document.body.appendChild(elem);
+      }, #{example_config});
+    EOS
+
+    it 'rounds the size to include all sub-pixels' do
+      run_happo
+      path = snapshot_file_name(description, '@large', 'current.png')
+      image = ChunkyPNG::Image.from_file(path)
+      expect(image.height).to eq(21)
+      expect(image.width).to eq(31)
+    end
+  end
+
   describe 'with an overflowing element' do
     let(:examples_js) { <<-EOS }
       happo.define('#{description}', function() {


### PR DESCRIPTION
Some components may have sub-pixel values for their location or
dimensions. Due to the way we were rounding values, this would cause
them to be incorrectly cropped, which made them lose the final row or
column of pixels. I fixed this by rounding top/left down and
right/bottom up before calculating the width and height, which ensures
that we always include the entire component in the screenshot.

Fixes #151