### PR TITLE
Prevent <SmoothProgress> from being wider than window

### DIFF
--- a/lib/happo/public/happo-styles.css
+++ b/lib/happo/public/happo-styles.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   background-color: #ebebeb;
   background-image: linear-gradient(
@@ -139,6 +143,7 @@ body {
   overflow: hidden;
   height: 10px;
   width: 100%;
+  max-width: calc(100vw - 20px);
   border: 1px solid #cccccc;
   border-radius: 5px;
   transition: opacity 1s;


### PR DESCRIPTION
The progress bar that displays during diff computation is designed to be
the width of the image. This is nice because it gives a hint to what
size the resulting diff image is going to be. When the image is wider
than the available screen space however, it gets confusing. I've been
looking at a few (really large) diffs where it looked like progress was
at 100% when it was in fact like 60%. Using a max-width here helps
prevent this.

After being confused that my `calc` was resulting in the wrong value, I
realized that I was in content-box land (oh the horror). So I added a
general rule to move us over to border-box.

I'm starting to feel the pain of:
- not being able to use variables (the 10px must be kept in sync with
  other places)
- not having styles better attached to the components
- not having a css reset (that would have most likely taken care of the
  box-sizing issue)