### PR TITLE
Process targets serially to prevent collision

### DIFF
--- a/packages/happo/src/__tests__/processSerially-test.js
+++ b/packages/happo/src/__tests__/processSerially-test.js
@@ -1,0 +1,19 @@
+const processSerially = require('../processSerially');
+
+it('returns the data in order', () => {
+  const data = ['a', 'b', 'c'];
+  const fn = x => Promise.resolve(x);
+  return processSerially(data, fn).then((results) => {
+    expect(results).toEqual(data);
+  });
+});
+
+it('runs serially', () => {
+  const data = [50, 0, 8];
+  const fn = x => new Promise((resolve) => {
+    setTimeout(() => resolve(x), x);
+  });
+  return processSerially(data, fn).then((results) => {
+    expect(results).toEqual(data);
+  });
+});

--- a/packages/happo/src/cli.js
+++ b/packages/happo/src/cli.js
@@ -9,6 +9,7 @@ const {
 const initializeConfig = require('./initializeConfig');
 const validateConfig = require('./validateConfig');
 const { server, uploadLastResult } = require('happo-viewer');
+const processSerially = require('./processSerially');
 
 config.set(validateConfig(initializeConfig(process.env.HAPPO_CONFIG_FILE)));
 
@@ -34,7 +35,7 @@ commander.command('run [<target>]').action((targetName) => {
   if (targetName) {
     resultPromise = targetForName(targetName).run();
   } else {
-    resultPromise = Promise.all(config.get().targets.map(target => target.run()))
+    resultPromise = processSerially(config.get().targets, target => target.run())
       .then(results => results.reduce((a, b) => a.merge(b)));
   }
 

--- a/packages/happo/src/processSerially.js
+++ b/packages/happo/src/processSerially.js
@@ -1,0 +1,9 @@
+module.exports = function processSerially(items, fn) {
+  const promises = [];
+  items.reduce((prev, item) => {
+    const promise = prev.then(() => fn(item));
+    promises.push(promise);
+    return promise;
+  }, Promise.resolve());
+  return Promise.all(promises);
+};


### PR DESCRIPTION
to: @lencioni @trotzig 

This is required in the CLI, because when you define multiple targets we want them to run serially rather than in parallel, since they will likely use some of the same ports and what not.