### PR TITLE
Update import-js config for all packages

### DIFF
--- a/packages/happo-core/.importjs.js
+++ b/packages/happo-core/.importjs.js
@@ -1,0 +1,1 @@
+module.exports = require('../../.importjs.js');

--- a/packages/happo-target-firefox/.importjs.js
+++ b/packages/happo-target-firefox/.importjs.js
@@ -1,0 +1,1 @@
+module.exports = require('../../.importjs.js');

--- a/packages/happo-target-firefox/src/server.js
+++ b/packages/happo-target-firefox/src/server.js
@@ -1,4 +1,5 @@
 const path = require('path');
+
 const prepareViewData = require('./prepareViewData');
 
 function isValidResource(file, options) {

--- a/packages/happo-viewer/.importjs.js
+++ b/packages/happo-viewer/.importjs.js
@@ -1,8 +1,8 @@
 module.exports = {
-  environments: ['node'],
+  environments: ['browser'],
   excludes: [
+    './public/**',
     './lib/**',
     './**/__tests__/**',
   ],
-  declarationKeyword: 'const',
 };

--- a/packages/happo/.importjs.js
+++ b/packages/happo/.importjs.js
@@ -1,0 +1,1 @@
+module.exports = require('../../.importjs.js');


### PR DESCRIPTION
To make import-js [1] work correctly, we need to configure it a little.

Most of our packages are node projects using CommonJS imports and
exports, so I created a root .importjs.js that package-specific config
then inherited. These projects also transpile code into a `lib` folder,
plus have test files in `__tests__` folders, so it was easy to set up
the excludes configuration (which controls what files import-js won't
import for you).

The happo-viewer package was treated differently since it mostly has
client-side React code where we use es6 imports and exports.

[1]: https://github.com/Galooshi/import-js