### PR TITLE
Pin selenium-webdriver at 3.3.0

### DIFF
--- a/packages/happo-target-firefox/package.json
+++ b/packages/happo-target-firefox/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "happo-core": "^5.0.0-rc.1",
     "pngjs": "^3.0.0",
-    "selenium-webdriver": "^3.0.1",
+    "selenium-webdriver": "3.3.0",
     "mkdirp": "^0.5.1",
     "ps-node": "^0.1.4",
     "express": "^4.14.0",


### PR DESCRIPTION
Version 3.4.0 is giving us errors:

```
(node:2070) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
/home/travis/build/org/project/node_modules/selenium-webdriver/lib/promise.js:2634
        throw error;
        ^
WebDriverError: Unable to parse new session response:
{"sessionId":"c22dff5b-04a4-41a1-804a-59b106ca81ec","value":{"acceptInsecureCerts":false,"browserName":"firefox","browserVersion":"52.0.1","moz:accessibilityChecks":false,"moz:processID":2096,"moz:profile":"/tmp/rust_mozprofile.6Kn1fST0TASk","pageLoadStrategy":"normal","platformName":"linux","platformVersion":"3.13.0-105-generic","rotatable":false,"specificationLevel":0,"timeouts":{"implicit":0,"page
load":300000,"script":30000}}}
```

I haven't had time to dig into this any deeper, but locking to 3.3.0
should fix the issue at least temporary.

Fixes #200