### PR TITLE
Improve error reporting

### DIFF
--- a/packages/happo-target-firefox/src/waitForImagesToRender.js
+++ b/packages/happo-target-firefox/src/waitForImagesToRender.js
@@ -3,7 +3,7 @@ import findBackgroundImageUrls from './findBackgroundImageUrls';
 function waitForImageToLoad(url) {
   return new Promise((resolve, reject) => {
     const img = new Image();
-    img.onerror = () => reject(new Error(`Failed to load image with url ${url}`));
+    img.onerror = () => reject(new Error(`Happo: Failed to load image with url ${url}`));
     img.addEventListener('load', resolve, { once: true });
     img.src = url;
   });


### PR DESCRIPTION
Took me some time to figure out where the error was coming from. That should help.

> Failed to load image with url data:image/svg+xml;utf8,<svg%20viewBox=\'0%200%2010%2011\'%20xmlns=\'http://www.w3.org/2000/svg\'><g%20stroke=\'%23bfc7d8\'%20stroke-width=\'1.5\'%20fill=\'none\'%20fill-rule=\'evenodd\'%20stroke-linecap=\'round\'><path%20d=\'M5%201.5v8M9%205.5H1\'/></g></svg>

Also linked to #207.