### PR TITLE
[happo-viewer] Bump worker-loader ^0.7.1 -> ^1.0.0

### DIFF
--- a/packages/happo-viewer/package.json
+++ b/packages/happo-viewer/package.json
@@ -24,7 +24,7 @@
     "ps-node": "^0.1.4",
     "express": "^4.14.0",
     "ejs": "^2.5.2",
-    "worker-loader": "^0.7.1",
+    "worker-loader": "^1.0.0",
     "cssesc": "^1.0.0"
   }
 }


### PR DESCRIPTION
worker-loader pre-1.0.0 has a peerDependency that does not allow webpack
3. This prevents projects that want to update to webpack 3 from getting
onto that version.

The only breaking change listed here is about loader-utils, which I
don't think will impact this project.

https://github.com/webpack-contrib/worker-loader/releases/tag/v1.0.0