### PR TITLE
Wait for images defined in srcset attributes

### DIFF
--- a/packages/happo-target-firefox/src/__tests__/fixtures/srcsetExample.js
+++ b/packages/happo-target-firefox/src/__tests__/fixtures/srcsetExample.js
@@ -1,0 +1,10 @@
+happo.define('foo', () => {
+  const elem = document.createElement('div');
+  elem.innerHTML = `
+    <img
+      style="display: block"
+      srcset="https://picsum.photos/50/50 300w, https://picsum.photos/200/200 500w"
+    >
+  `;
+  document.body.appendChild(elem);
+}, { viewports: ['small'] });

--- a/packages/happo-target-firefox/src/__tests__/runVisualDiffs-test.js
+++ b/packages/happo-target-firefox/src/__tests__/runVisualDiffs-test.js
@@ -107,7 +107,7 @@ describe('runVisualDiffs', () => {
 
       return runVisualDiffs(driver, options).then((result) => {
         expect(result.newImages.length).toEqual(1);
-        expect(result.newImages[0].height).toEqual(1);
+        expect(result.newImages[0].height).toBeGreaterThan(0);
       });
     });
 
@@ -136,18 +136,31 @@ describe('runVisualDiffs', () => {
       options.sourceFiles.push(fixturePath('tallExample.js'));
 
       return runVisualDiffs(driver, options).then((firstResult) => {
+        const { height } = firstResult.newImages[0];
         expect(firstResult.newImages.length).toEqual(1);
         expect(firstResult.diffImages.length).toEqual(0);
-        expect(firstResult.newImages[0].height).toEqual(100);
+        expect(height).toBeGreaterThan(99);
 
         // Switch to a short example
         options.sourceFiles.pop();
         options.sourceFiles.push(fixturePath('shortExample.js'));
-      }).then(() => runVisualDiffs(driver, options)).then((secondResult) => {
-        expect(secondResult.diffImages.length).toEqual(1);
+        return runVisualDiffs(driver, options).then((secondResult) => {
+          expect(secondResult.diffImages.length).toEqual(1);
 
-        // We expect height to be the max of the before and after
-        expect(secondResult.diffImages[0].height).toEqual(100);
+          // We expect height to be the max of the before and after
+          expect(secondResult.diffImages[0].height).toEqual(height);
+        });
+      });
+    });
+
+    it('waits for images in srcset', () => {
+      // Use a tall example to begin with
+      options.sourceFiles.push(fixturePath('srcsetExample.js'));
+
+      return runVisualDiffs(driver, options).then((firstResult) => {
+        expect(firstResult.newImages.length).toEqual(1);
+        expect(firstResult.diffImages.length).toEqual(0);
+        expect(firstResult.newImages[0].height).toBeGreaterThan(100);
       });
     });
   });

--- a/packages/happo-target-firefox/src/waitForImagesToRender.js
+++ b/packages/happo-target-firefox/src/waitForImagesToRender.js
@@ -11,10 +11,23 @@ export function waitForImageToLoad(url) {
 
 export default function waitForImagesToRender() {
   return new Promise((resolve, reject) => {
-    const promises = Array.prototype.slice.call(document.querySelectorAll('img'))
+    const images = Array.prototype.slice.call(document.querySelectorAll('img'));
+    const promises = images
       .map(img => img.src)
       .filter(Boolean)
       .map(waitForImageToLoad);
+
+    images.forEach((img) => {
+      const srcset = img.getAttribute('srcset');
+      if (!srcset) {
+        return;
+      }
+
+      srcset.split(/,\s*/).forEach((entry) => {
+        const [url] = entry.split(' ');
+        promises.push(waitForImageToLoad(url));
+      });
+    });
 
     Array.prototype.slice.call(document.body.querySelectorAll('*'))
       .forEach((element) => {


### PR DESCRIPTION
This commit is a port of changes I've made to the new runner for
happo.io. By waiting for images in srcset attributes, we can prevent
spurious diffs.

Instead of trying to figure out which one of the images will be
displayed in the current viewport, I decided to download all. The
tradeoff here being simplicity over performance (dowloading only one of
the images would be faster).

While running tests locally, I noticed that I was getting 2x images
compared to what's in CI. I decided to make the assertions a little
looser to account for both 1x and 2x screenshots.