### PR TITLE
Use string.prototype.matchall to grab urls from srcset

### DIFF
--- a/packages/happo-target-firefox/package.json
+++ b/packages/happo-target-firefox/package.json
@@ -24,6 +24,7 @@
     "pngjs": "^3.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "selenium-webdriver": "3.6.0"
+    "selenium-webdriver": "3.6.0",
+    "string.prototype.matchall": "^3.0.0"
   }
 }

--- a/packages/happo-target-firefox/src/getUrlsFromSrcset.js
+++ b/packages/happo-target-firefox/src/getUrlsFromSrcset.js
@@ -1,10 +1,7 @@
+import matchAll from 'string.prototype.matchall';
+
 const SRCSET_ITEM = /([^\s]+)(\s+[0-9.]+[wx])?(,?\s*)/g;
 
 export default function getUrlsFromSrcset(value) {
-  const result = [];
-  let match;
-  while (match = SRCSET_ITEM.exec(value)) { // eslint-disable-line no-cond-assign
-    result.push(match[1]);
-  }
-  return result;
+  return Array.from(matchAll(value, SRCSET_ITEM)).map(groups => groups[1]);
 }

--- a/packages/happo-target-firefox/src/getUrlsFromSrcset.js
+++ b/packages/happo-target-firefox/src/getUrlsFromSrcset.js
@@ -3,5 +3,5 @@ import matchAll from 'string.prototype.matchall';
 const SRCSET_ITEM = /([^\s]+)(\s+[0-9.]+[wx])?(,?\s*)/g;
 
 export default function getUrlsFromSrcset(value) {
-  return Array.from(matchAll(value, SRCSET_ITEM)).map(groups => groups[1]);
+  return Array.from(matchAll(value, SRCSET_ITEM), groups => groups[1]);
 }


### PR DESCRIPTION
As pointed out by @ljharb in a previous PR: https://github.com/Galooshi/happo/pull/224#pullrequestreview-127401748

Multiple benefits here:
- we avoid the while-loop
- no mutation of the lastIndex property of the regexp