### PR TITLE
Wait for images with crossorigin=anonymous

### DIFF
--- a/packages/happo-target-firefox/package.json
+++ b/packages/happo-target-firefox/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "ejs": "^2.5.2",
     "express": "^4.14.0",
-    "geckodriver": "^1.9.0",
+    "geckodriver": "1.9.0",
     "happo-core": "^5.0.0",
     "happo-viewer": "^5.0.0",
     "mkdirp": "^0.5.1",

--- a/packages/happo-target-firefox/src/__tests__/fixtures/crossOriginImageExample.js
+++ b/packages/happo-target-firefox/src/__tests__/fixtures/crossOriginImageExample.js
@@ -1,0 +1,5 @@
+happo.define('img', () => {
+  const elem = document.createElement('div');
+  elem.innerHTML = '<img src="https://placekitten.com/200/287" crossorigin="anonymous">';
+  document.body.appendChild(elem);
+}, { viewports: ['medium'] });

--- a/packages/happo-target-firefox/src/__tests__/fixtures/crossOriginImageExample.js
+++ b/packages/happo-target-firefox/src/__tests__/fixtures/crossOriginImageExample.js
@@ -1,5 +1,0 @@
-happo.define('img', () => {
-  const elem = document.createElement('div');
-  elem.innerHTML = '<img src="https://placekitten.com/200/287" crossorigin="anonymous">';
-  document.body.appendChild(elem);
-}, { viewports: ['medium'] });

--- a/packages/happo-target-firefox/src/__tests__/fixtures/crossOriginImageExamples.js
+++ b/packages/happo-target-firefox/src/__tests__/fixtures/crossOriginImageExamples.js
@@ -1,0 +1,17 @@
+happo.define('regular img with crossOrigin', () => {
+  const elem = document.createElement('div');
+  elem.innerHTML = '<img src="https://placekitten.com/200/287" crossorigin="anonymous">';
+  document.body.appendChild(elem);
+}, { viewports: ['medium'] });
+
+happo.define('srcset img with crossOrigin', () => {
+  const elem = document.createElement('div');
+  elem.innerHTML = '<img srcset="https://picsum.photos/50/50 300w, https://picsum.photos/200/200 500w" crossorigin="anonymous">';
+  document.body.appendChild(elem);
+}, { viewports: ['medium'] });
+
+happo.define('background-image', () => {
+  const elem = document.createElement('div');
+  elem.style = 'background-image: url(https://picsum.photos/500/500); height: 200px; width: 200px;';
+  document.body.appendChild(elem);
+}, { viewports: ['medium'] });

--- a/packages/happo-target-firefox/src/__tests__/runVisualDiffs-test.js
+++ b/packages/happo-target-firefox/src/__tests__/runVisualDiffs-test.js
@@ -153,6 +153,17 @@ describe('runVisualDiffs', () => {
       });
     });
 
+    it('waits for images with crossOrigin', () => {
+      // Use a tall example to begin with
+      options.sourceFiles.push(fixturePath('crossOriginImageExample.js'));
+
+      return runVisualDiffs(driver, options).then((firstResult) => {
+        expect(firstResult.newImages.length).toEqual(1);
+        expect(firstResult.diffImages.length).toEqual(0);
+        expect(firstResult.newImages[0].height).toBeGreaterThan(100);
+      });
+    });
+
     it('waits for images in srcset', () => {
       // Use a tall example to begin with
       options.sourceFiles.push(fixturePath('srcsetExample.js'));

--- a/packages/happo-target-firefox/src/__tests__/runVisualDiffs-test.js
+++ b/packages/happo-target-firefox/src/__tests__/runVisualDiffs-test.js
@@ -154,13 +154,14 @@ describe('runVisualDiffs', () => {
     });
 
     it('waits for images with crossOrigin', () => {
-      // Use a tall example to begin with
-      options.sourceFiles.push(fixturePath('crossOriginImageExample.js'));
+      options.sourceFiles.push(fixturePath('crossOriginImageExamples.js'));
 
       return runVisualDiffs(driver, options).then((firstResult) => {
-        expect(firstResult.newImages.length).toEqual(1);
+        expect(firstResult.newImages.length).toEqual(3);
         expect(firstResult.diffImages.length).toEqual(0);
         expect(firstResult.newImages[0].height).toBeGreaterThan(100);
+        expect(firstResult.newImages[1].height).toBeGreaterThan(100);
+        expect(firstResult.newImages[2].height).toBeGreaterThan(100);
       });
     });
 

--- a/packages/happo-target-firefox/src/__tests__/waitForImagesToRender-test.js
+++ b/packages/happo-target-firefox/src/__tests__/waitForImagesToRender-test.js
@@ -1,13 +1,39 @@
 import { waitForImageToLoad } from '../waitForImagesToRender';
 
-const image = "data:image/svg+xml;utf8,<svg%20viewBox='0%200%2010%2011'%20xmlns='http://www.w3.org/2000/svg'><g%20stroke='%23bfc7d8'%20stroke-width='1.5'%20fill='none'%20fill-rule='evenodd'%20stroke-linecap='round'><path%20d='M5%201.5v8M9%205.5H1'/></g></svg>";
 
 describe('waitForImagesToRender', () => {
   describe('waitForImageToLoad', () => {
-    it('should handle data uris correctly', () => (
-      waitForImageToLoad(image).then((output) => {
+    it('should handle data uris correctly', () => {
+      const image = "data:image/svg+xml;utf8,<svg%20viewBox='0%200%2010%2011'%20xmlns='http://www.w3.org/2000/svg'><g%20stroke='%23bfc7d8'%20stroke-width='1.5'%20fill='none'%20fill-rule='evenodd'%20stroke-linecap='round'><path%20d='M5%201.5v8M9%205.5H1'/></g></svg>";
+      return waitForImageToLoad(image).then((output) => {
         expect(output.type).toBe('load');
-      })
-    ));
+      });
+    });
+
+    it('handles image urls', () => {
+      const image = 'https://placekitten.com/200/287';
+      return waitForImageToLoad(image).then((output) => {
+        expect(output.type).toBe('load');
+      });
+    });
+
+    it('handles image elements', () => {
+      const image = {
+        src: 'https://placekitten.com/200/287',
+      };
+      return waitForImageToLoad(image).then((output) => {
+        expect(output.type).toBe('load');
+      });
+    });
+
+    it('handles image elements with crossOrigin attributes', () => {
+      const image = {
+        src: 'https://placekitten.com/200/287',
+        crossOrigin: 'anonymous',
+      };
+      return waitForImageToLoad(image).then((output) => {
+        expect(output.type).toBe('load');
+      });
+    });
   });
 });

--- a/packages/happo-target-firefox/src/__tests__/waitForImagesToRender-test.js
+++ b/packages/happo-target-firefox/src/__tests__/waitForImagesToRender-test.js
@@ -3,35 +3,26 @@ import { waitForImageToLoad } from '../waitForImagesToRender';
 
 describe('waitForImagesToRender', () => {
   describe('waitForImageToLoad', () => {
-    it('should handle data uris correctly', () => {
-      const image = "data:image/svg+xml;utf8,<svg%20viewBox='0%200%2010%2011'%20xmlns='http://www.w3.org/2000/svg'><g%20stroke='%23bfc7d8'%20stroke-width='1.5'%20fill='none'%20fill-rule='evenodd'%20stroke-linecap='round'><path%20d='M5%201.5v8M9%205.5H1'/></g></svg>";
-      return waitForImageToLoad(image).then((output) => {
+    it('handles data uris correctly', () => {
+      const src = "data:image/svg+xml;utf8,<svg%20viewBox='0%200%2010%2011'%20xmlns='http://www.w3.org/2000/svg'><g%20stroke='%23bfc7d8'%20stroke-width='1.5'%20fill='none'%20fill-rule='evenodd'%20stroke-linecap='round'><path%20d='M5%201.5v8M9%205.5H1'/></g></svg>";
+      return waitForImageToLoad({ src }).then((output) => {
         expect(output.type).toBe('load');
       });
     });
 
-    it('handles image urls', () => {
-      const image = 'https://placekitten.com/200/287';
-      return waitForImageToLoad(image).then((output) => {
+    it('handles images', () => {
+      const src = 'https://placekitten.com/200/287';
+      return waitForImageToLoad({ src }).then((output) => {
         expect(output.type).toBe('load');
       });
     });
 
-    it('handles image elements', () => {
-      const image = {
-        src: 'https://placekitten.com/200/287',
-      };
-      return waitForImageToLoad(image).then((output) => {
-        expect(output.type).toBe('load');
-      });
-    });
-
-    it('handles image elements with crossOrigin attributes', () => {
-      const image = {
+    it('handles crossOrigin attributes', () => {
+      const props = {
         src: 'https://placekitten.com/200/287',
         crossOrigin: 'anonymous',
       };
-      return waitForImageToLoad(image).then((output) => {
+      return waitForImageToLoad(props).then((output) => {
         expect(output.type).toBe('load');
       });
     });

--- a/packages/happo-target-firefox/src/waitForImagesToRender.js
+++ b/packages/happo-target-firefox/src/waitForImagesToRender.js
@@ -1,11 +1,18 @@
 import findBackgroundImageUrls from './findBackgroundImageUrls';
 import getUrlsFromSrcset from './getUrlsFromSrcset';
 
-export function waitForImageToLoad(url) {
+export function waitForImageToLoad(imageOrUrl) {
   return new Promise((resolve, reject) => {
+    let url = imageOrUrl;
+    let crossOrigin;
+    if (typeof imageOrUrl !== 'string') {
+      url = imageOrUrl.src;
+      crossOrigin = imageOrUrl.crossOrigin;
+    }
     const img = new Image();
     img.onerror = () => reject(new Error(`Happo: Failed to load image with url ${url}`));
     img.addEventListener('load', resolve, { once: true });
+    img.crossOrigin = crossOrigin;
     img.src = url;
   });
 }
@@ -14,8 +21,7 @@ export default function waitForImagesToRender() {
   return new Promise((resolve, reject) => {
     const images = Array.prototype.slice.call(document.querySelectorAll('img'));
     const promises = images
-      .map(img => img.src)
-      .filter(Boolean)
+      .filter(({ src }) => !!src)
       .map(waitForImageToLoad);
 
     images.forEach((img) => {


### PR DESCRIPTION
I've had spurious diffs reported from images with a crossorigin
attribute. This could be because the browser kicks off different
requests for the crossorigin image and the preloaded image. This creates
a race condition: if the crossorigin image isn't ready by the time the
preload image is downloaded, it won't show up in the screenshot. We can
fix this by transferring crossorigin information from the original image
to the temporary Image created as part of preloading.