### PR TITLE
Replace srcset parsing regex with parse-srcset package

### DIFF
--- a/packages/happo-target-firefox/package.json
+++ b/packages/happo-target-firefox/package.json
@@ -21,10 +21,10 @@
     "happo-core": "^5.0.0",
     "happo-viewer": "^5.0.0",
     "mkdirp": "^0.5.1",
+    "parse-srcset": "^1.0.2",
     "pngjs": "^3.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "selenium-webdriver": "3.6.0",
-    "string.prototype.matchall": "^3.0.0"
+    "selenium-webdriver": "3.6.0"
   }
 }

--- a/packages/happo-target-firefox/src/__tests__/getUrlsFromSrcset-test.js
+++ b/packages/happo-target-firefox/src/__tests__/getUrlsFromSrcset-test.js
@@ -41,3 +41,7 @@ it('handles multiple urls with whitespace', () => {
 
   `)).toEqual(['http://foo.com/foo,40,50', '/bar,20.png']);
 });
+
+it('handles multiple URLs with mixed descriptors', () => {
+  expect(getUrlsFromSrcset('/foo.png, /bar.png 400w')).toEqual(['/foo.png', '/bar.png']);
+});

--- a/packages/happo-target-firefox/src/__tests__/runVisualDiffs-test.js
+++ b/packages/happo-target-firefox/src/__tests__/runVisualDiffs-test.js
@@ -30,6 +30,7 @@ describe('runVisualDiffs', () => {
       uploader: () => ({}),
       targets: [],
     });
+
     options = {
       ...defaultOptions,
       bind: '0.0.0.0',
@@ -40,8 +41,10 @@ describe('runVisualDiffs', () => {
       ],
       stylesheets: [],
     };
+
     return server.start(options).then(({ expressServer }) => {
       startedServer = expressServer;
+
       return initializeWebdriver(options).then((webdriver) => {
         driver = webdriver;
       });

--- a/packages/happo-target-firefox/src/getUrlsFromSrcset.js
+++ b/packages/happo-target-firefox/src/getUrlsFromSrcset.js
@@ -1,7 +1,5 @@
-import matchAll from 'string.prototype.matchall';
-
-const SRCSET_ITEM = /([^\s]+)(\s+[0-9.]+[wx])?(,?\s*)/g;
+import parseSrcset from 'parse-srcset';
 
 export default function getUrlsFromSrcset(value) {
-  return Array.from(matchAll(value, SRCSET_ITEM), groups => groups[1]);
+  return parseSrcset(value).map((parsed) => parsed.url);
 }


### PR DESCRIPTION
We found a bug where srcsets with multiple URLs and mixed descriptors
would be parsed incorrectly, causing the first URL without a descriptor
to include a trailing comma. Instead of relying on this regex, I found
what appears to be a good package for parsing this string according to
the spec.

@trotzig @ljharb @sharmilajesupaul